### PR TITLE
Pica: Add missing memory header

### DIFF
--- a/source/video_core/src/video_core/shader.hpp
+++ b/source/video_core/src/video_core/shader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <initializer_list>
+#include <memory>
 
 #include "../support/common/common_types.h"
 


### PR DESCRIPTION
This one is needed for `std::unique_ptr`, otherwise things won’t compile.