### PR TITLE
Vulkan: Use the DynamicLoader from the right namespace

### DIFF
--- a/source/video_core/utils/vulkan_utils/device_manager.hpp
+++ b/source/video_core/utils/vulkan_utils/device_manager.hpp
@@ -9,7 +9,7 @@ class logger;
 }
 
 struct VulkanInstanceManager {
-    vk::DynamicLoader vulkan_loader;
+    vk::detail::DynamicLoader vulkan_loader;
     vk::UniqueInstance instance;
 
     VulkanInstanceManager(spdlog::logger&, const char* app_name, const std::vector<const char*>& required_instance_extensions);


### PR DESCRIPTION
As of vulkan-headers 1.4.303, this class is defined in the `vk::detail` namespace, not in `vk` any more.