### PR TITLE
Fixes for newer system versions

### DIFF
--- a/source/platform/fs.hpp
+++ b/source/platform/fs.hpp
@@ -409,6 +409,21 @@ using DeleteExtSaveData = IPC::IPCCommand<0x852>::add_serialized<ExtSaveDataInfo
 
 /**
  * Inputs:
+ * - Output Extdata ID buffer size
+ * - Media Type (and other unknown flags)
+ * - Extdata ID size (4 or 8)
+ * - Is Shared
+ * - Output Extdata ID buffer
+ *
+ * Error codes:
+ * - 0xe0c046fa: Gamecard extdata is not supported
+ * - 0xe0e046bc: Invalid buffer size or Extdata ID size
+ */
+using EnumerateExtSaveData = IPC::IPCCommand<0x855>::add_uint32::add_uint32::add_uint32::add_uint32::add_buffer_mapping_write
+                                ::response::add_uint32::add_buffer_mapping_write;
+
+/**
+ * Inputs:
  * - Media type (and other things?)
  * - Save id
  * - Total size

--- a/source/processes/dsp.cpp
+++ b/source/processes/dsp.cpp
@@ -783,6 +783,12 @@ void FakeDSP::OnIPCRequest(FakeThread& thread, Handle sender, const IPC::Command
         thread.WriteTLS(0x88, 0); // not inserted
         break;
 
+    // ForceHeadphoneOut
+    case 0x20:
+        thread.WriteTLS(0x80, IPC::CommandHeader::Make(0x20, 1, 0).raw);
+        thread.WriteTLS(0x84, RESULT_OK);
+        break;
+
     default:
         // TODO: Throw and catch IPCError instead
         throw std::runtime_error(fmt::format("Unknown DSP IPC request {:#x}", header.command_id.Value()));

--- a/source/processes/fs.cpp
+++ b/source/processes/fs.cpp
@@ -2235,6 +2235,18 @@ decltype(HLE::OS::ServiceHelper::SendReply) FakeFS::UserCommandHandler(FakeThrea
         thread.WriteTLS(0x88, 0);
         break;
 
+    case 0x87d: // GetNumSeeds (HOME Menu)
+        thread.WriteTLS(0x80, IPC::CommandHeader::Make(0, 2, 0).raw);
+        thread.WriteTLS(0x84, RESULT_OK);
+        thread.WriteTLS(0x88, 0);
+        break;
+
+    case 0x883: // GetNumTitleTags (HOME Menu)
+        thread.WriteTLS(0x80, IPC::CommandHeader::Make(0, 2, 0).raw);
+        thread.WriteTLS(0x84, RESULT_OK);
+        thread.WriteTLS(0x88, 0);
+        break;
+
     default:
         throw Mikage::Exceptions::NotImplemented("Unknown FS service command with header {:#010x}", header.raw);
     }

--- a/source/processes/fs.cpp
+++ b/source/processes/fs.cpp
@@ -1442,6 +1442,13 @@ public:
         const bool duplicate_data = false; // TODO: Verify this is the returned value
         provider.EnsureFormatted(ArchiveFormatInfo { size, max_directories, max_files, duplicate_data });
 
+        // Write SMDH icon
+        std::filesystem::path base_path = BuildBasePath(context, info, is_shared);
+        std::ofstream icon(base_path / "icon", std::ios::binary);
+        for (uint32_t i = 0; i < smdh_icon.size; ++i) {
+            icon << thread.ReadMemory(smdh_icon.addr + i);
+        }
+
         return RESULT_OK;
     }
 

--- a/source/processes/fs.hpp
+++ b/source/processes/fs.hpp
@@ -202,6 +202,9 @@ public: // TODO: Un-public-ize
                                                    uint64_t save_id, uint32_t smdh_size, uint32_t num_directories, uint32_t num_files,
                                                    IPC::MappedBuffer smdh);
     std::tuple<OS::Result> HandleDeleteExtSaveData(FakeThread& thread, ProcessId session_id, const Platform::FS::ExtSaveDataInfo& info);
+    std::tuple<OS::Result, uint32_t, IPC::MappedBuffer> HandleEnumerateExtSaveData(FakeThread&, ProcessId, uint32_t, uint32_t media_type,
+                                                                                   uint32_t id_entry_size, uint32_t is_shared,
+                                                                                   IPC::MappedBuffer output_ids);
     std::tuple<OS::Result> HandleCreateSystemSaveData(FakeThread& thread, ProcessId session_id, uint32_t media_type, uint32_t save_id,
                                                       uint32_t total_size, uint32_t block_size, uint32_t num_directories,
                                                       uint32_t num_files, uint32_t unk1, uint32_t unk2, uint32_t unk3);

--- a/source/processes/ptm.cpp
+++ b/source/processes/ptm.cpp
@@ -366,8 +366,9 @@ void FakePTM::CommandHandler_gets(FakeThread& thread, const IPC::CommandHeader& 
         thread.WriteTLS(0x8c, 0);
         break;
 
-    default:
-        throw std::runtime_error(fmt::format("Unknown PTM command request with header {:#010x}", header.raw));
+    default: // May be a ptm:u command
+        FakePTM::CommandHandler(thread, header);
+        break;
     }
 }
 


### PR DESCRIPTION
- Fix `ptm:gets` command handler not falling back to `ptm:u` for `ptm:u` commands
    - This fixes the following from #26:
    >  Unimplemented ptm:gets request 0x000c0000 (GetTotalStepCount)
- Extdata improvements:
	- Add support for SpotPass extdata (required during initial setup)
	- Write SMDH icon during extdata creation (will be required for listing extdata in System Settings)
- Add stubs for `fs:USER:GetNumSeeds` and `fs:USER:GetNumTitleTags` (required by HOME menu)
    - This fixes the following from #26:
     > HOME Menu requires FS commands 0x0883/0x87d
- Implement stub for `dsp::DSP:ForceHeadphoneOut` (required when rebooting out of initial setup)
- Implement `fs:USER:EnumerateExtSaveData`, allowing a user to enter "Extra Data" in System Settings -> Data Management -> Nintendo 3DS


