### PR TITLE
Document START key, add Shift for SELECT key

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ You'll need to `source conanrun.sh` to set up library directories.
 * Q key: L
 * E key: R
 * IJKL keys: D-pad
+* Enter key: START
+* Shift key: SELECT
 
 ## Debugging
 

--- a/source/gui-sdl/main.cpp
+++ b/source/gui-sdl/main.cpp
@@ -639,6 +639,11 @@ if (bootstrap_nand) // Experimental system bootstrapper
                     input.SetPressedStart(pressed);
                     break;
 
+                case SDLK_LSHIFT:
+                case SDLK_RSHIFT:
+                    input.SetPressetSelect(pressed);
+                    break;
+
                 case SDLK_a:
                     circle_pad.first -= 1.0f * (pressed ? 1.0 : -1.0);
                     input.SetCirclePad(circle_pad.first, circle_pad.second);


### PR DESCRIPTION
Not sure if there's a preference on where the SELECT key should be. Shift just happened to be near Enter.
But I also don't think it really matters too much considering how rarely SELECT was used in games and that this isn't for end-users yet.