### PR TITLE
Pica: Add to AlphaTest::Function for Kirby Triple Deluxe

### DIFF
--- a/source/gui-sdl/main.cpp
+++ b/source/gui-sdl/main.cpp
@@ -641,7 +641,7 @@ if (bootstrap_nand) // Experimental system bootstrapper
 
                 case SDLK_LSHIFT:
                 case SDLK_RSHIFT:
-                    input.SetPressetSelect(pressed);
+                    input.SetPressedSelect(pressed);
                     break;
 
                 case SDLK_a:

--- a/source/platform/gpu/pica.hpp
+++ b/source/platform/gpu/pica.hpp
@@ -35,6 +35,8 @@ struct AlphaTest {
     enum class Function : uint32_t {
         Always             = 1,
         NotEqual           = 3,
+        LessThan           = 4,
+        LessThanOrEqual    = 5,
         GreaterThan        = 6,
         GreaterThanOrEqual = 7,
     };

--- a/source/video_core/src/video_core/vulkan/shader_gen.cpp
+++ b/source/video_core/src/video_core/vulkan/shader_gen.cpp
@@ -669,6 +669,12 @@ std::string GenerateFragmentShader(Context& context) {
             switch (func) {
             case AlphaTest::Function::NotEqual:
                 return "==";
+            
+            case AlphaTest::Function::LessThan:
+                return ">=";
+
+            case AlphaTest::Function::LessThanOrEqual:
+                return ">";
 
             case AlphaTest::Function::GreaterThan:
                 return "<=";


### PR DESCRIPTION
This adds `Pica::AlphaTest::Function::LessThan` and `Pica::AlphaTest::Function::LessThanOrEqual` for Kirby Triple Deluxe, as mentioned in #56, based on https://docs.mikage.app/GPU/Internal_Registers/#gpureg_fragop_alpha_test.
This also mends a small typo in the last PR.