### PR TITLE
[arm, video_core] remove deprecated std::is_pod

### DIFF
--- a/source/arm.h
+++ b/source/arm.h
@@ -391,7 +391,7 @@ struct State {
 
     uint64_t cycle_count;
 };
-static_assert(std::is_pod<State>::value, "State is not a POD type");
+static_assert(std::is_standard_layout_v<State> && std::is_trivial_v<State>, "State is not a POD type");
 
 enum class OperandShifterMode : uint32_t {
     LSL = 0,     // Logical Shift Left

--- a/source/video_core/src/video_core/shader.hpp
+++ b/source/video_core/src/video_core/shader.hpp
@@ -31,7 +31,7 @@ struct InputVertex {
 //    Math::Vec4<float24> attr[16];
     std::array<Math::Vec4<float24>, 16> attr;
 };
-static_assert(std::is_pod<InputVertex>::value, "Structure is not POD");
+static_assert(std::is_standard_layout_v<InputVertex> && std::is_trivial_v<InputVertex>, "Structure is not POD");
 
 struct OutputVertex {
     OutputVertex() = default;
@@ -77,7 +77,7 @@ struct OutputVertex {
         return ret;
     }
 };
-static_assert(std::is_pod<OutputVertex>::value, "Structure is not POD");
+static_assert(std::is_standard_layout_v<OutputVertex> && std::is_trivial_v<OutputVertex>, "Structure is not POD");
 static_assert(sizeof(OutputVertex) == 32 * sizeof(float), "OutputVertex has invalid size");
 
 struct ShaderEngine {


### PR DESCRIPTION
Replaced with is_trivial_v && is_standard_layout_v

Signed-off-by: crueter <crueter@eden-emu.dev>
