### PR TITLE
[cmake] output binaries into `build/bin`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,15 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Put binaries into <build>/bin
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+
 add_compile_options(-Werror=implicit-fallthrough)
 add_compile_options(-Werror=return-type)
 add_compile_options(-Werror=unused-result)
 
 # Prefer Conan-provided packages over system ones
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
-
 
 # TODO: Move these flags into a "boost" cmake target
 add_definitions(-DBOOST_FILESYSTEM_NO_DEPRECATED -DBOOST_COROUTINES_NO_DEPRECATION_WARNING)


### PR DESCRIPTION
This is preferred because it places all binaries in the same place
rather than having to search through the entire build tree.

Signed-off-by: crueter <crueter@eden-emu.dev>
