### PR TITLE
[*] fix various warnings, prefer uint64_t over ull, better unreachable

### DIFF
--- a/source/debug/os.cpp
+++ b/source/debug/os.cpp
@@ -122,7 +122,7 @@ static void doProcessThreadList(OSService& service, const Pistache::Rest::Reques
         }();
 
         // TODO: Send jitcontextid only for EmuThreads!
-        auto emu_thread = dynamic_cast<HLE::OS::EmuThread*>(&thread);
+        // auto emu_thread = dynamic_cast<HLE::OS::EmuThread*>(&thread);
         auto jitcontextid = 4294967297; // TODO: Retrieve from emu_thread
         body += fmt::format(R"({{ "id": {}, "pid": {}, "name": "{}", "status": "{}", "jitcontextid": {} }},)",
                             tid_and_thread.first, thread.GetParentProcess().GetId(), thread.GetName(),

--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Adding an interface library to propagate include directories
-add_library(framework exceptions.cpp profiler.cpp)
+add_library(framework exceptions.cpp profiler.cpp
+    unreachable.h)
 target_include_directories(framework INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
 target_link_libraries(framework PUBLIC fmt::fmt)

--- a/source/framework/profiler.cpp
+++ b/source/framework/profiler.cpp
@@ -125,7 +125,7 @@ FrozenMetrics Activity::GetMetricsAt(TimePoint now) const {
         ret.sub_metrics.emplace_back(activity.GetMetricsAt(now));
     }
     }
-    return std::move(ret);
+    return ret;
 }
 
 FrozenMetrics Profiler::Freeze() const {

--- a/source/framework/unreachable.h
+++ b/source/framework/unreachable.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(_MSC_VER)
+#define UNREACHABLE() __assume(0)
+#elif defined(__GNUC__) || defined(__clang__)
+#define UNREACHABLE() __builtin_unreachable()
+#else
+#define UNREACHABLE()
+#endif

--- a/source/gdb_stub.cpp
+++ b/source/gdb_stub.cpp
@@ -115,7 +115,7 @@ static std::optional<CombinedProcessThreadId> ParseProcessThreadId(const std::st
  * @todo we shouldn't be using the HLE::OS::ProcessId type for this protocol-specific quantity!
  */
 static bool IsAnyProcess(HLE::OS::ProcessId pid) {
-    return pid == 0 || pid == -1;
+    return pid == 0 || pid == uint32_t(-1);
 }
 
 /**
@@ -123,7 +123,7 @@ static bool IsAnyProcess(HLE::OS::ProcessId pid) {
  * @todo we shouldn't be using the HLE::OS::ThreadId type for this protocol-specific quantity!
  */
 static bool IsAnyThread(HLE::OS::ThreadId tid) {
-    return tid == 0 || tid == -1;
+    return tid == 0 || tid == uint32_t(-1);
 }
 
 /**

--- a/source/interpreter.cpp
+++ b/source/interpreter.cpp
@@ -251,7 +251,7 @@ static void UpdateCPSR_C_FromBorrow(CPUContext& ctx, uint32_t left, uint32_t rig
 }
 
 static void UpdateCPSR_C_FromBorrow(CPUContext& ctx, uint32_t left, uint32_t right, uint32_t cpsr_c) {
-    bool borrow = left < (static_cast<uint64_t>(right) + !cpsr_c);
+    bool borrow = left < (uint64_t(right) + !cpsr_c);
     ctx.cpu.cpsr.carry = !borrow;
 }
 
@@ -271,8 +271,8 @@ static void UpdateCPSR_V_FromSub(CPUContext& ctx, uint32_t left, uint32_t right,
 static void UpdateCPSR_V_FromSub(CPUContext& ctx, uint32_t left, uint32_t right, uint32_t result, uint32_t carry) {
     right = ~right;
     // TODO: Portability!
-    uint64_t signed_sum = static_cast<int64_t>(static_cast<int32_t>(left)) + static_cast<int64_t>(static_cast<int32_t>(right)) + static_cast<uint64_t>(carry);
-    ctx.cpu.cpsr.overflow = static_cast<int64_t>(static_cast<int32_t>(result)) != signed_sum;
+    uint64_t signed_sum = int64_t(int32_t(left)) + int64_t(int32_t(right)) + uint64_t(carry);
+    ctx.cpu.cpsr.overflow = int64_t(int32_t(result)) != signed_sum;
 }
 
 // Evaluates the given condition based on CPSR

--- a/source/loader/gamecard.cpp
+++ b/source/loader/gamecard.cpp
@@ -419,7 +419,7 @@ public:
         // Read program sections
         uint32_t text_numpages = ((dot3dsxheader.text_size + 0xfff) >> 12);
         uint32_t ro_numpages = ((dot3dsxheader.ro_size + 0xfff) >> 12);
-        uint32_t data_numpages = (((dot3dsxheader.data_bss_size - dot3dsxheader.bss_size) + 0xfff) >> 12);
+        // uint32_t data_numpages = (((dot3dsxheader.data_bss_size - dot3dsxheader.bss_size) + 0xfff) >> 12);
 
         uint32_t text_vaddr = 0x00100000;
         uint32_t ro_vaddr = text_vaddr + (text_numpages << 12);

--- a/source/os.hpp
+++ b/source/os.hpp
@@ -1217,7 +1217,7 @@ class ServerPort : public ObserverSubject {
     uint32_t available_sessions;
 
 public:
-    ServerPort(std::shared_ptr<Port> port, uint32_t max_sessions) : port(port), available_sessions(max_sessions) {
+    ServerPort(std::shared_ptr<Port> port, uint32_t max_sessions) : available_sessions(max_sessions), port(port) {
     }
 
     virtual ~ServerPort() = default;

--- a/source/platform/sm.hpp
+++ b/source/platform/sm.hpp
@@ -30,7 +30,7 @@ struct PortName {
         std::string strname(name);
         length = strname.length();
         uint32_t value = 0;
-        for (int i = 0; i < 8; ++i) {
+        for (uint32_t i = 0; i < 8; ++i) {
             char c = (i < length) ? strname[i] : 0;
             value = (c << 24) | (value >> 8);
             if (i == 3 || i == 7) {

--- a/source/processes/am.cpp
+++ b/source/processes/am.cpp
@@ -147,10 +147,10 @@ static auto AppCommandHandler(FakeThread& thread, FakeAM& context, const Platfor
         thread.WriteTLS(0x90, addr);
 //        thread.WriteMemory32(addr, /*0xe22f26aa*/ 00022000); // mset
 //        thread.WriteMemory32(addr + 4, /*0x0004feda*/ 00040010);
-for (int i = 0; i < num_tickets; ++i) {
-        thread.WriteMemory32(addr + i * 8, /*0xe22f26aa*/ (*nand_titles)[i] & 0xffffffff); // mset
-        thread.WriteMemory32(addr + 4 + i * 8, /*0x0004feda*/ (*nand_titles)[i] >> 32);
-}
+        for (uint32_t i = 0; i < num_tickets; ++i) {
+                thread.WriteMemory32(addr + i * 8, /*0xe22f26aa*/ (*nand_titles)[i] & 0xffffffff); // mset
+                thread.WriteMemory32(addr + 4 + i * 8, /*0x0004feda*/ (*nand_titles)[i] >> 32);
+        }
         break;
     }
 

--- a/source/processes/dsp.cpp
+++ b/source/processes/dsp.cpp
@@ -575,7 +575,7 @@ static auto BindMemFn(Func f, Class* c) {
     return boost::hana::partial(std::mem_fn(f), c);
 }
 
-static int lol = 0; // TODO: Un-global-ize
+// static int lol = 0; // TODO: Un-global-ize
 void FakeDSP::OnIPCRequest(FakeThread& thread, Handle sender, const IPC::CommandHeader& header) {
     switch (header.command_id) {
     case 0x1: // RecvData

--- a/source/processes/fs_hpv.cpp
+++ b/source/processes/fs_hpv.cpp
@@ -365,7 +365,7 @@ struct FSUserService : SessionToPort {
                                            flags, attributes);
             Session::OnRequest(hypervisor, thread, session, description);
 
-            response.OnResponse([=](Hypervisor& hv, Thread& thread, Result result, Handle file_session_handle) {
+            response.OnResponse([=, this](Hypervisor& hv, Thread& thread, Result result, Handle file_session_handle) {
                 if (result != RESULT_OK) {
                     return;
                 }
@@ -389,7 +389,7 @@ struct FSUserService : SessionToPort {
                                            flags, attributes);
             Session::OnRequest(hypervisor, thread, session, description);
 
-            response.OnResponse([=](Hypervisor& hv, Thread& thread, Result result, Handle file_session_handle) {
+            response.OnResponse([=, this](Hypervisor& hv, Thread& thread, Result result, Handle file_session_handle) {
                 if (result != RESULT_OK) {
                     return;
                 }
@@ -464,7 +464,7 @@ struct FSUserService : SessionToPort {
                                            RawPathToString(thread, dir_path_type, dir_path_size, dir_path));
             Session::OnRequest(hypervisor, thread, session, description);
 
-            response.OnResponse([=](Hypervisor& hv, Thread& thread, Result result, Handle dir_session_handle) {
+            response.OnResponse([=, this](Hypervisor& hv, Thread& thread, Result result, Handle dir_session_handle) {
                 if (result != RESULT_OK) {
                     return;
                 }
@@ -480,7 +480,7 @@ struct FSUserService : SessionToPort {
                                            RawPathToString(thread, archive_path_type, archive_path_size, archive_path));
             Session::OnRequest(hypervisor, thread, session, description);
 
-            response.OnResponse([=](Hypervisor&, Thread& thread, Result result, FS::ArchiveHandle archive_handle) {
+            response.OnResponse([=, this](Hypervisor&, Thread& thread, Result result, FS::ArchiveHandle archive_handle) {
                 if (result != RESULT_OK) {
                     return;
                     // TODO: Enable this once we stop using dummy archives!

--- a/source/processes/ns.cpp
+++ b/source/processes/ns.cpp
@@ -321,8 +321,8 @@ OS::ResultAnd<ProcessId> LaunchTitleInternal(FakeThread& source, bool from_firm,
     // Register the created process to srv:pm
     // TODO: Enable this code...
     // TODO: Now that we fixed SM HLE, WE REALLY NEED TO DO THIS PROPERLY INSTEAD. I.e. have loader do this, and have loader register these via pm
-    auto not_null = [](auto letter) { return letter != 0; };
-    auto nonempty_entry = [&](const auto& service) { return boost::algorithm::any_of(service, not_null); };
+    // auto not_null = [](auto letter) { return letter != 0; };
+    // auto nonempty_entry = [&](const auto& service) { return boost::algorithm::any_of(service, not_null); };
 //    bool needs_services = boost::algorithm::any_of(exheader.service_access_list, nonempty_entry);
     if (false && needs_services) {
         // Register process through "srv:pm"
@@ -344,7 +344,7 @@ OS::ResultAnd<ProcessId> LaunchTitleInternal(FakeThread& source, bool from_firm,
         auto service_acl_addr = parent_process.AllocateStaticBuffer(service_acl_size);
         auto service_acl_numentries = service_acl_size / service_acl_entry_size;
 
-        for (auto off = 0; off < sizeof(exheader.aci.service_access_list); ++off) {
+        for (uint64_t off = 0; off < sizeof(exheader.aci.service_access_list); ++off) {
             auto entry = off / service_acl_entry_size;
             auto byte = off % service_acl_entry_size;
             source.WriteMemory(service_acl_addr + off, exheader.aci.service_access_list[entry][byte]);

--- a/source/processes/ns_hpv.cpp
+++ b/source/processes/ns_hpv.cpp
@@ -23,8 +23,8 @@ const char* ToString(Platform::NS::AppletPos pos) {
     case AppletPos::SysLib:   return "SysLib";
     case AppletPos::Resident: return "Resident";
     case AppletPos::AppLib2:  return "AppLib2";
-    case static_cast<AppletPos>(0xff): return "None?"; // Observed by swkbd during initialization
-    case static_cast<AppletPos>(0xffffffff): return "None?"; // Observed by ctrulib when switching to home menu
+    case AppletPos(0xff): return "None?"; // Observed by swkbd during initialization
+    case AppletPos(0xffffffff): return "None?"; // Observed by ctrulib when switching to home menu
     default:                  throw std::runtime_error("Unknown AppletPos");
     }
 }

--- a/source/video_core/externals/nihstro/include/nihstro/shader_bytecode.h
+++ b/source/video_core/externals/nihstro/include/nihstro/shader_bytecode.h
@@ -28,12 +28,12 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <stdexcept>
 #include <string>
 #include <sstream>
 
 #include "bit_field.h"
+#include "framework/unreachable.h"
 
 namespace nihstro {
 
@@ -80,12 +80,16 @@ struct SourceRegister {
     }
 
     int GetIndex() const {
-        if (GetRegisterType() == RegisterType::Input)
+        switch (GetRegisterType()) {
+        case RegisterType::Input:
             return value;
-        else if (GetRegisterType() == RegisterType::Temporary)
+        case RegisterType::Temporary:
             return value - 0x10;
-        else if (GetRegisterType() == RegisterType::FloatUniform)
+        case RegisterType::FloatUniform:
             return value - 0x20;
+        default:
+            UNREACHABLE();
+        }
     }
 
     static const SourceRegister FromTypeAndIndex(RegisterType type, int index) {

--- a/source/video_core/src/debug/gpu.cpp
+++ b/source/video_core/src/debug/gpu.cpp
@@ -191,7 +191,7 @@ static void DoGetBytecode(GPUService& service, const Pistache::Rest::Request& re
 static void DoGetGLSL(GPUService& service, const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response) {
     std::lock_guard guard(service.access_mutex);
 
-    auto key = std::stoull(request.param(":key").as<std::string>(), 0, 16);
+    // auto key = std::stoull(request.param(":key").as<std::string>(), 0, 16);
 
     response.headers().add<Http::Header::AccessControlAllowOrigin>("*");
     response.headers().add<Http::Header::ContentType>(Http::Mime::MediaType { Http::Mime::Type::Application, Http::Mime::Subtype::Json });

--- a/source/video_core/src/video_core/debug_utils/debug_utils.cpp
+++ b/source/video_core/src/video_core/debug_utils/debug_utils.cpp
@@ -257,7 +257,7 @@ std::unique_ptr<PicaTrace> FinishPicaTracing()
     pica_trace_mutex.lock();
     std::unique_ptr<PicaTrace> ret(std::move(pica_trace));
     pica_trace_mutex.unlock();
-    return std::move(ret);
+    return ret;
 }
 
 const Math::Vec4<u8> LookupTexture(Memory::HostMemoryBackedPages source_memory, int x, int y, const TextureInfo& info, bool disable_alpha) {
@@ -569,9 +569,9 @@ void DumpTexture(const Pica::TextureConfig& texture_config, u8* data) {
     return;
 
 #ifndef HAVE_PNG
-	return;
+    return;
 #else
-	if (!data)
+    if (!data)
         return;
 
     // Write data to file

--- a/source/video_core/src/video_core/rasterizer.cpp
+++ b/source/video_core/src/video_core/rasterizer.cpp
@@ -809,6 +809,9 @@ static void ProcessTriangleInternal(Context& context,
 
                     case StencilTest::CompareFunc::GreaterThanOrEqual:
                         return ref >= current;
+
+                    default:
+                        return true;
                     }
                 };
                 stencil_passed = compare_stencil(   stencil_test.compare_function(),

--- a/source/video_core/src/video_core/shader_glsl.cpp
+++ b/source/video_core/src/video_core/shader_glsl.cpp
@@ -2306,7 +2306,7 @@ static std::string TranslateToGLSL(Context& context, Instruction instr) {
             return fmt::format("uniforms.f[{}{}]", reg.GetIndex(), address_register_index ? fmt::format(" + a{}", *address_register_index) : "");
 
         default:
-            __builtin_unreachable();
+            UNREACHABLE();
         }
     };
 
@@ -2319,7 +2319,7 @@ static std::string TranslateToGLSL(Context& context, Instruction instr) {
             return fmt::format("temp_{}", reg.GetIndex());
 
         default:
-            __builtin_unreachable();
+            UNREACHABLE();
         }
     };
 

--- a/source/video_core/src/video_core/shader_interpreter.cpp
+++ b/source/video_core/src/video_core/shader_interpreter.cpp
@@ -1,11 +1,10 @@
 #include <framework/exceptions.hpp>
 
-#include <stack>
+#include <utility>
 
 #include <common/log.h>
 
 #include <nihstro/shader_bytecode.h>
-
 
 #include "context.h"
 #include "shader.hpp"
@@ -477,6 +476,9 @@ static void ProcessShaderCode(Context& context, ShaderInterpreter& engine) {
 
                 case flow_control.JustY:
                     return results[1];
+
+                default:
+                    UNREACHABLE();
                 }
             };
 

--- a/source/video_core/src/video_core/shader_microcode.cpp
+++ b/source/video_core/src/video_core/shader_microcode.cpp
@@ -856,6 +856,9 @@ static std::string WriteCondition(Instruction::FlowControlType instr) {
 
     case Op::JustY:
         return component(1);
+
+    default:
+        UNREACHABLE();
     }
 }
 
@@ -877,7 +880,7 @@ static std::string TranslateToGLSL(Context& context, Instruction instr) {
             return fmt::format("uniforms.f[{}{}]", reg.GetIndex(), address_register_index ? fmt::format(" + a{}", *address_register_index) : "");
 
         default:
-            __builtin_unreachable();
+            UNREACHABLE();
         }
     };
 
@@ -890,7 +893,7 @@ static std::string TranslateToGLSL(Context& context, Instruction instr) {
             return fmt::format("temp_{}", reg.GetIndex());
 
         default:
-            __builtin_unreachable();
+            UNREACHABLE();
         }
     };
 

--- a/source/video_core/src/video_core/vertex_loader.hpp
+++ b/source/video_core/src/video_core/vertex_loader.hpp
@@ -63,7 +63,7 @@ public:
         // TODO: Add bounds check on vertex! When initializing vertex_attribute_sources, we should compute the maximum vertex index possible and compare against that
         // TODO: Verify all vertex_attribute_sources used have actually been initialized
 
-        for (int i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
+        for (uint32_t i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
             auto& attr = input.attr[i];
             if (!vertex_attribute_sources[i]) { // TODO: Check vertex_attribute_elements and vertex_attribute_element_size instead?
                 // TODO: Required by lego batman during bootup?
@@ -117,7 +117,7 @@ public:
     GetUsedAddressRanges(const Regs::VertexAttributes& attribute_config, uint32_t min_index, uint32_t end_index) const {
         std::array<std::pair<uint32_t, uint32_t>, 16> ret {};
 
-        for (int i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
+        for (uint32_t i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
             if (!vertex_attribute_sources[i]) {
                 continue;
             }
@@ -172,7 +172,7 @@ private:
     VertexShader::InputVertex GetDefaultAttributes(const Context& context, const Regs::VertexAttributes& attribute_config) const {
         VertexShader::InputVertex input;
 
-        for (int i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
+        for (uint32_t i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
             auto& attr = input.attr[i];
 
             if (vertex_attribute_elements[i]) {

--- a/source/video_core/src/video_core/vulkan/renderer.cpp
+++ b/source/video_core/src/video_core/vulkan/renderer.cpp
@@ -279,8 +279,8 @@ void Renderer::ProduceFrame(EmuDisplay::EmuDisplay& display, EmuDisplay::Frame& 
     ZoneScoped;
     auto scope_measure = MeasureScope(*activity, "FrameProduction");
 
-            auto& image = frame.image;
-            auto& memory = frame.buffer_memory;
+            // auto& image = frame.image;
+            // auto& memory = frame.buffer_memory;
 
 //                part.in_use_by_cpu[buffer_index] = true;
 //                part.in_use_by_gpu[buffer_index] = { }; // Initialized by frontend before toggling in_use_by_cpu back to false
@@ -658,7 +658,7 @@ void Renderer::FinalizeTriangleBatchInternal(Context& context, const VertexShade
 
                 // TODO: Do we need to factor in vertex_attribute_element_size[idx], too?
 
-                uint32_t vertex_stride = loader.vertex_attribute_strides[i]; // in bytes. TODO: Do we need to care about alignment?
+                // uint32_t vertex_stride = loader.vertex_attribute_strides[i]; // in bytes. TODO: Do we need to care about alignment?
                 const uint32_t binding_index = i;
                 const uint32_t binding_stride = loader_config.byte_count;
                 // TODO: Use device requirements instead

--- a/source/video_core/src/video_core/vulkan/resource_manager.cpp
+++ b/source/video_core/src/video_core/vulkan/resource_manager.cpp
@@ -1076,8 +1076,8 @@ void RenderTargetResource::ProtectBackingEmulatedMemory(Memory::PhysicalMemory& 
                                     [&](PAddr page_addr) -> Memory::ReadHandler* {
                                         auto& tracked_page = manager.GetTrackedMemoryPage(page_addr);
 
-                                        const bool is_first_read_hook =
-                                            (tracked_page.resources.end() == ranges::find_if(tracked_page.resources, Memory::HasReadHook, &TrackedMemoryPage::Entry::hook_kind));
+                                        // const bool is_first_read_hook =
+                                        //     (tracked_page.resources.end() == ranges::find_if(tracked_page.resources, Memory::HasReadHook, &TrackedMemoryPage::Entry::hook_kind));
 
                                         // If this Resource is already registered,
                                         // add the ReadHook flag to it. Otherwise,

--- a/source/video_core/src/video_core/vulkan/shader_gen.cpp
+++ b/source/video_core/src/video_core/vulkan/shader_gen.cpp
@@ -349,8 +349,8 @@ std::string GenerateFragmentShader(Context& context) {
         using AlphaModifier = Regs::TevStageConfig::AlphaModifier;
         using Operation = Regs::TevStageConfig::Operation;
 
-        const bool is_nop_stage_rgb = (tev_stage.color_modifier1() == ColorModifier::SourceColor && tev_stage.color_op() == Operation::Replace);
-        const bool is_nop_stage_a = (tev_stage.alpha_modifier1() == AlphaModifier::SourceAlpha && tev_stage.alpha_op() == Operation::Replace);
+        // const bool is_nop_stage_rgb = (tev_stage.color_modifier1() == ColorModifier::SourceColor && tev_stage.color_op() == Operation::Replace);
+        // const bool is_nop_stage_a = (tev_stage.alpha_modifier1() == AlphaModifier::SourceAlpha && tev_stage.alpha_op() == Operation::Replace);
 
         std::string tev_stage_str = "tev" + std::to_string(tev_stage_index) + "_";
 
@@ -669,7 +669,7 @@ std::string GenerateFragmentShader(Context& context) {
             switch (func) {
             case AlphaTest::Function::NotEqual:
                 return "==";
-            
+
             case AlphaTest::Function::LessThan:
                 return ">=";
 

--- a/source/video_core/utils/vulkan_utils/memory_types.hpp
+++ b/source/video_core/utils/vulkan_utils/memory_types.hpp
@@ -48,7 +48,7 @@ public:
             }
 
             auto& type = properties.memoryTypes[type_index];
-            auto& heap = properties.memoryHeaps[type.heapIndex];
+            // auto& heap = properties.memoryHeaps[type.heapIndex];
 
             if ((desired_flags & type.propertyFlags) == desired_flags) {
                 return { size, type_index };

--- a/tools/install_cia/main.cpp
+++ b/tools/install_cia/main.cpp
@@ -114,11 +114,11 @@ CIA ParseCIA(std::ifstream& file) {
     std::cout << std::endl;
 
     // TODO: Handle overflow cases for large content_size values..
-    auto cert_begin = static_cast<unsigned long long>(cia_begin) + (unsigned long long){(cia.header_size + 63) & ~UINT32_C(63)};
-    auto ticket_begin = cert_begin + (unsigned long long){(cia.certificate_chain_size + 63) & ~UINT32_C(63)};
-    auto tmd_begin = ticket_begin + (unsigned long long){(cia.ticket_size + 63) & ~UINT32_C(63)};
-    auto content_begin = tmd_begin + (unsigned long long){(cia.tmd_size + 63) & ~UINT32_C(63)};
-    auto meta_begin = content_begin + (unsigned long long){(cia.content_size + 63) & ~UINT32_C(63)};
+    auto cert_begin = static_cast<uint64_t>(cia_begin) + uint64_t{(cia.header_size + 63) & ~UINT32_C(63)};
+    auto ticket_begin = cert_begin + uint64_t{(cia.certificate_chain_size + 63) & ~UINT32_C(63)};
+    auto tmd_begin = ticket_begin + uint64_t{(cia.ticket_size + 63) & ~UINT32_C(63)};
+    auto content_begin = tmd_begin + uint64_t{(cia.tmd_size + 63) & ~UINT32_C(63)};
+    auto meta_begin = content_begin + uint64_t{(cia.content_size + 63) & ~UINT32_C(63)};
 
     file.seekg(cert_begin);
     strbuf_it = std::istreambuf_iterator<char>(file.rdbuf());


### PR DESCRIPTION
- Fixed a bunch of random warnings. There's still a bunch left but
whatever.
- Always prefer uint64_t over unsigned long long. They're the same
  thing, but one is shorter
- Made a platform-agnostic UNREACHABLE() macro so that this can compile
  on MSVC in the future maybe. Also used this macro to mark some
  unenumerated switch/if-paths as unreachable which should result in
  marginally better codegen.

Signed-off-by: crueter <crueter@eden-emu.dev>
