### PR TITLE
Add support for any-region NAND bootstrap

### DIFF
--- a/source/gui-sdl/main.cpp
+++ b/source/gui-sdl/main.cpp
@@ -4,6 +4,7 @@
 
 #include "platform/file_formats/cia.hpp"
 #include "platform/file_formats/ncch.hpp"
+#include "platform/config.hpp"
 #include "processes/pxi_fs.hpp"
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
 
@@ -234,142 +235,217 @@ int main(int argc, char* argv[]) {
 
     auto keydb = LoadKeyDatabase(*frontend_logger, "./aes_keys.txt");
 
-if (bootstrap_nand) // Experimental system bootstrapper
-    try {
-        // TODO: Replicate the functionality of ns:s's CardUpdateInitialize on boot:
-        //       Compare the title version of CVer in emulated NAND against the title
-        //       version in the TMD of the CVer CIA in the game update partition.
+    if (bootstrap_nand) { // Experimental system bootstrapper
+        // Note: These lists are ordered by system region!
+        constexpr std::array<uint64_t, 7> cver_title_ids = {
+            0x000400db'00017202, 0x000400db'00017302,
+            0x000400db'00017102, 0x000400db'00017102,
+            0x000400db'00017402, 0x000400db'00017502,
+            0x000400db'00017602,
+        };
+        
+        constexpr std::array<uint64_t, 7> nver_title_ids = {
+            0x000400db'00016202, 0x000400db'00016302,
+            0x000400db'00016102, 0x000400db'00016102,
+            0x000400db'00016402, 0x000400db'00016502,
+            0x000400db'00016602,
+        };
+        
+        constexpr std::array<uint64_t, 7> system_font_title_ids = {
+            0x0004009b'00014002, 0x0004009b'00014002,
+            0x0004009b'00014002, 0x0004009b'00014002,
+            0x0004009b'00014102, 0x0004009b'00014202,
+            0x0004009b'00014302,
+        };
+        
+        constexpr std::array<uint64_t, 7> eula_title_ids = {
+            0x0004009b'00013202, 0x0004009b'00013302,
+            0x0004009b'00013102, 0x0004009b'00013102,
+            0x0004009b'00013402, 0x0004009b'00013502,
+            0x0004009b'00013602,
+        };
+        
+        constexpr std::array<uint64_t, 3> common_sysdata_title_ids = {
+             0x0004009b'00010202, 0x000400db'00010302, 0x0004009b'00010402,
+        };
+        
 
-        auto gamecard = LoadGameCard(*frontend_logger, settings);
-        auto update_partition = gamecard->GetPartitionFromId(Loader::NCSDPartitionId::UpdateData);
-        if (!update_partition) {
-            throw std::runtime_error("Couldn't find update partition");
-        }
+        Platform::Config::SystemRegion sysregion = Platform::Config::SystemRegion::Invalid;
+        bool had_eula = false;
 
-        auto file_context = HLE::PXI::FS::FileContext { *frontend_logger };
-        auto [result] = (*update_partition)->OpenReadOnly(file_context);
-        if (result != HLE::OS::RESULT_OK) {
-            throw std::runtime_error("Failed to open update partition");
-        }
-
-        // Open RomFS for update partition
-        auto romfs = HLE::PXI::FS::NCCHOpenExeFSSection(*frontend_logger, file_context, keydb, std::move(*update_partition), 0, {});
-
-        FileFormat::RomFSLevel3Header level3_header;
-        const uint32_t lv3_offset = 0x1000;
-
-        std::tie(result) = romfs->OpenReadOnly(file_context);
-        uint32_t bytes_read;
-        std::tie(result, bytes_read) = romfs->Read(file_context, lv3_offset, sizeof(level3_header), HLE::PXI::FS::FileBufferInHostMemory(level3_header));
-        if (result != HLE::OS::RESULT_OK) {
-            throw std::runtime_error("Failed to read update partition RomFS");
-        }
-
-        std::filesystem::path content_dir = settings.get<Settings::PathDataDir>() + "/data";
-
-        for (uint32_t metadata_offset = 0; metadata_offset < level3_header.file_metadata_size;) {
-            FileFormat::RomFSFileMetadata file_metadata;
-            std::tie(result, bytes_read) = romfs->Read(file_context, lv3_offset + level3_header.file_metadata_offset + metadata_offset, sizeof(file_metadata), HLE::PXI::FS::FileBufferInHostMemory(file_metadata));
-            if (result != HLE::OS::RESULT_OK) {
-                throw std::runtime_error("Failed to read file metadata");
+        try {
+            // TODO: Replicate the functionality of ns:s's CardUpdateInitialize on boot:
+            //       Compare the title version of CVer in emulated NAND against the title
+            //       version in the TMD of the CVer CIA in the game update partition.
+    
+            auto gamecard = LoadGameCard(*frontend_logger, settings);
+            auto update_partition = gamecard->GetPartitionFromId(Loader::NCSDPartitionId::UpdateData);
+            if (!update_partition) {
+                throw std::runtime_error("Couldn't find update partition");
             }
-            metadata_offset += sizeof(file_metadata);
-
-            std::u16string filename;
-            filename.resize((file_metadata.name_size + 1) / 2);
-            std::tie(result, bytes_read) = romfs->Read(file_context, lv3_offset + level3_header.file_metadata_offset + metadata_offset, file_metadata.name_size, HLE::PXI::FS::FileBufferInHostMemory(filename.data(), file_metadata.name_size));
+    
+            auto file_context = HLE::PXI::FS::FileContext { *frontend_logger };
+            auto [result] = (*update_partition)->OpenReadOnly(file_context);
             if (result != HLE::OS::RESULT_OK) {
-                throw std::runtime_error("Failed to read filename from metadata");
+                throw std::runtime_error("Failed to open update partition");
             }
-
-            std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> conversion;
-            std::string filename2 { conversion.to_bytes(filename) };
-
-            fprintf(stderr, "FOUND FILENAME: %s\n", filename2.c_str());
-
-            if (filename2.ends_with(".cia")) {
-                auto cia_file = std::make_unique<HLE::PXI::FS::FileView>(std::move(romfs), lv3_offset + level3_header.file_data_offset + file_metadata.data_offset, file_metadata.data_size);
-                FileFormat::CIAHeader cia_header;
-                std::tie(result, bytes_read) = cia_file->Read(file_context, 0, sizeof(cia_header), HLE::PXI::FS::FileBufferInHostMemory(cia_header));
+    
+            // Open RomFS for update partition
+            auto romfs = HLE::PXI::FS::NCCHOpenExeFSSection(*frontend_logger, file_context, keydb, std::move(*update_partition), 0, {});
+    
+            FileFormat::RomFSLevel3Header level3_header;
+            const uint32_t lv3_offset = 0x1000;
+    
+            std::tie(result) = romfs->OpenReadOnly(file_context);
+            uint32_t bytes_read;
+            std::tie(result, bytes_read) = romfs->Read(file_context, lv3_offset, sizeof(level3_header), HLE::PXI::FS::FileBufferInHostMemory(level3_header));
+            if (result != HLE::OS::RESULT_OK) {
+                throw std::runtime_error("Failed to read update partition RomFS");
+            }
+    
+            std::filesystem::path content_dir = settings.get<Settings::PathDataDir>() + "/data";
+            
+            for (uint32_t metadata_offset = 0; metadata_offset < level3_header.file_metadata_size;) {
+                FileFormat::RomFSFileMetadata file_metadata;
+                std::tie(result, bytes_read) = romfs->Read(file_context, lv3_offset + level3_header.file_metadata_offset + metadata_offset, sizeof(file_metadata), HLE::PXI::FS::FileBufferInHostMemory(file_metadata));
                 if (result != HLE::OS::RESULT_OK) {
-                    throw std::runtime_error("Failed to read file data");
+                    throw std::runtime_error("Failed to read file metadata");
                 }
-
-                fprintf(stderr, "CIA header size: %#x\n", cia_header.header_size);
-
-                InstallCIA(content_dir, *frontend_logger, keydb, file_context, *cia_file);
-
-                romfs = cia_file->ReleaseParentAndClose();
+                metadata_offset += sizeof(file_metadata);
+    
+                std::u16string filename;
+                filename.resize((file_metadata.name_size + 1) / 2);
+                std::tie(result, bytes_read) = romfs->Read(file_context, lv3_offset + level3_header.file_metadata_offset + metadata_offset, file_metadata.name_size, HLE::PXI::FS::FileBufferInHostMemory(filename.data(), file_metadata.name_size));
+                if (result != HLE::OS::RESULT_OK) {
+                    throw std::runtime_error("Failed to read filename from metadata");
+                }
+    
+                std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> conversion;
+                std::string filename2 { conversion.to_bytes(filename) };
+    
+                fprintf(stderr, "FOUND FILENAME: %s\n", filename2.c_str());
+    
+                if (filename2.ends_with(".cia")) {
+                    uint64_t cur_title_id = 0;
+                    auto parse_res = std::from_chars(filename2.data(), filename2.data() + 16, cur_title_id, 16);
+                    if (parse_res.ptr != filename2.data() + 16) {
+                        throw std::runtime_error("Could not parse title ID in update partition");
+                    }
+                    
+                    auto cver_it = std::find(cver_title_ids.begin(), cver_title_ids.end(), cur_title_id);
+                    if (cver_it != cver_title_ids.end()) {
+                        if (sysregion != Platform::Config::SystemRegion::Invalid) {
+                            throw std::runtime_error("Detected multiple CVer titles in update partition");
+                        }
+                        
+                        sysregion = static_cast<decltype(sysregion)>(std::distance(cver_title_ids.begin(), cver_it));
+                    }
+                    
+                    if (!had_eula) {
+                        had_eula = std::find(eula_title_ids.begin(), eula_title_ids.end(), cur_title_id) != eula_title_ids.end();
+                    }
+                    
+                    auto cia_file = std::make_unique<HLE::PXI::FS::FileView>(std::move(romfs), lv3_offset + level3_header.file_data_offset + file_metadata.data_offset, file_metadata.data_size);
+                    FileFormat::CIAHeader cia_header;
+                    std::tie(result, bytes_read) = cia_file->Read(file_context, 0, sizeof(cia_header), HLE::PXI::FS::FileBufferInHostMemory(cia_header));
+                    if (result != HLE::OS::RESULT_OK) {
+                        throw std::runtime_error("Failed to read file data");
+                    }
+    
+                    fprintf(stderr, "CIA header size: %#x\n", cia_header.header_size);
+    
+                    InstallCIA(content_dir / "title", *frontend_logger, keydb, file_context, *cia_file);
+    
+                    romfs = cia_file->ReleaseParentAndClose();
+                }
+    
+                // Align filename size to 4 bytes
+                metadata_offset += (file_metadata.name_size + 3) & ~3;
             }
-
-            // Align filename size to 4 bytes
-            metadata_offset += (file_metadata.name_size + 3) & ~3;
+            
+            if (sysregion == Platform::Config::SystemRegion::Invalid) {
+                throw std::runtime_error("Could not find a CVer title in update partition");
+            }
+            
+            std::filesystem::create_directories(content_dir / "title/000400db");
+            std::filesystem::create_directories(content_dir / "title/0004009b");
+            
+            auto copy_title = [&settings, &content_dir](uint64_t title_id) -> void {
+                std::filesystem::copy( settings.get<Settings::PathImmutableDataDir>() + fmt::format("/nand/title/{:08x}/{:08x}", title_id >> 32, title_id & 0xFFFFFFFF), 
+                                       content_dir / fmt::format("title/{:08x}/{:08x}", title_id >> 32, title_id & 0xFFFFFFFF),
+                                       std::filesystem::copy_options::overwrite_existing | std::filesystem::copy_options::recursive);
+            };
+            
+            std::filesystem::create_directories(content_dir / "ro/sys");
+            std::filesystem::create_directories(content_dir / "rw/sys");
+            std::filesystem::create_directories(content_dir / "twlp");
+            
+            // Common titles for all regions
+            for (const uint64_t& common_sysdata_tid : common_sysdata_title_ids) {
+                copy_title(common_sysdata_tid);
+            }
+            
+            copy_title(nver_title_ids[Meta::to_underlying(sysregion)]);
+            copy_title(system_font_title_ids[Meta::to_underlying(sysregion)]);
+            if (!had_eula) {
+                copy_title(eula_title_ids[Meta::to_underlying(sysregion)]);
+            }
+    
+            // Create dummy HWCAL0, required for cfg module to work without running initial system setup first
+            char zero[128]{};
+            {
+                std::ofstream hwcal0(content_dir / "ro/sys/HWCAL0.dat");
+                const auto size = 2512;
+                for (unsigned i = 0; i < size / sizeof(zero); ++i) {
+                    hwcal0.write(zero, sizeof(zero));
+                }
+                hwcal0.write(zero, size % sizeof(zero));
+            }
+    
+            // Dump "logo" to have one for the 3DSX -> Gamecard adaptor
+            {
+                auto cxi_partition = gamecard->GetPartitionFromId(Loader::NCSDPartitionId::Executable);
+                if (!cxi_partition) {
+                    throw std::runtime_error("Could not find executable partition in gamecard image");
+                }
+                auto [cxi_open_res] = (*cxi_partition)->OpenReadOnly(file_context);
+    
+                if (cxi_open_res != HLE::OS::RESULT_OK) {
+                    throw std::runtime_error("Could not open executable partition of gamecard image");
+                }
+    
+                static constexpr const std::array<uint8_t, 8> logo_section_name = { 'l', 'o', 'g', 'o' };
+                auto logo_section = HLE::PXI::FS::NCCHOpenExeFSSection(*frontend_logger, file_context, keydb, std::move(*cxi_partition), 2, std::basic_string_view<uint8_t>(logo_section_name.data(), logo_section_name.size()));
+    
+                std::ofstream logo_file(settings.get<Settings::PathDataDir>() + "/placeholder_logo.bin", std::ios::binary);
+    
+                auto [res, logosize] = logo_section->GetSize(file_context);
+                if (res != HLE::OS::RESULT_OK || !logosize) {
+                    throw std::runtime_error("Could not get size of logo section in gamecart executable partition");
+                }
+    
+                std::vector<char> logobuf(logosize);
+                auto read_res = logo_section->Read(file_context, 0, logosize, HLE::PXI::FS::FileBufferInHostMemory(logobuf.data(), logosize));
+                if (read_res != std::tuple{ HLE::OS::RESULT_OK, logosize }) {
+                    throw std::runtime_error("Could not read logo section in gamecart executable partition");
+                }
+                logo_file.write(logobuf.data(), logosize);
+            }
+    
+            // Set up dummy rw/sys/SecureInfo_A with region based on CVer title ID
+            {
+                std::ofstream info(content_dir / "rw/sys/SecureInfo_A");
+                info.write(zero, sizeof(zero));
+                info.write(zero, sizeof(zero));
+                info.write(&reinterpret_cast<char&>(sysregion), 1);
+                info.write(zero, 0x10);
+            }
+    
+            // TODO: Set up shared font
+            // TODO: Set up GPIO
+        } catch (std::runtime_error&) {
+            throw;
         }
-
-        // Copy substitute titles
-        std::filesystem::copy(  settings.get<Settings::PathImmutableDataDir>() + "/nand/title", content_dir,
-                                std::filesystem::copy_options::skip_existing | std::filesystem::copy_options::recursive);
-
-        std::filesystem::create_directories(content_dir / "ro/sys");
-        std::filesystem::create_directories(content_dir / "rw/sys");
-        std::filesystem::create_directories(content_dir / "twlp");
-
-        // Create dummy HWCAL0, required for cfg module to work without running initial system setup first
-        char zero[128]{};
-        {
-            std::ofstream hwcal0(content_dir / "ro/sys/HWCAL0.dat");
-            const auto size = 2512;
-            for (unsigned i = 0; i < size / sizeof(zero); ++i) {
-                hwcal0.write(zero, sizeof(zero));
-            }
-            hwcal0.write(zero, size % sizeof(zero));
-        }
-
-        // Dump "logo" to have one for the 3DSX -> Gamecard adaptor
-        {
-            auto cxi_partition = gamecard->GetPartitionFromId(Loader::NCSDPartitionId::Executable);
-            if (!cxi_partition) {
-                throw std::runtime_error("Could not find executable partition in gamecard image");
-            }
-            auto [cxi_open_res] = (*cxi_partition)->OpenReadOnly(file_context);
-
-            if (cxi_open_res != HLE::OS::RESULT_OK) {
-                throw std::runtime_error("Could not open executable partition of gamecard image");
-            }
-
-            static constexpr const std::array<uint8_t, 8> logo_section_name = { 'l', 'o', 'g', 'o' };
-            auto logo_section = HLE::PXI::FS::NCCHOpenExeFSSection(*frontend_logger, file_context, keydb, std::move(*cxi_partition), 2, std::basic_string_view<uint8_t>(logo_section_name.data(), logo_section_name.size()));
-
-            std::ofstream logo_file(settings.get<Settings::PathDataDir>() + "/placeholder_logo.bin", std::ios::binary);
-
-            auto [res, logosize] = logo_section->GetSize(file_context);
-            if (res != HLE::OS::RESULT_OK || !logosize) {
-                throw std::runtime_error("Could not get size of logo section in gamecart executable partition");
-            }
-
-            std::vector<char> logobuf(logosize);
-            auto read_res = logo_section->Read(file_context, 0, logosize, HLE::PXI::FS::FileBufferInHostMemory(logobuf.data(), logosize));
-            if (read_res != std::tuple{ HLE::OS::RESULT_OK, logosize }) {
-                throw std::runtime_error("Could not read logo section in gamecart executable partition");
-            }
-            logo_file.write(logobuf.data(), logosize);
-        }
-
-        // Set up dummy rw/sys/SecureInfo_A with region EU
-        // TODO: Let the user select the region
-        {
-            std::ofstream info(content_dir / "rw/sys/SecureInfo_A");
-            info.write(zero, sizeof(zero));
-            info.write(zero, sizeof(zero));
-            char region = 2; // Europe
-            info.write(&region, 1);
-            info.write(zero, 0x10);
-        }
-
-        // TODO: Set up shared font
-        // TODO: Set up GPIO
-    } catch (std::runtime_error&) {
-        throw;
     }
 
     // Initialize SDL

--- a/source/platform/config.hpp
+++ b/source/platform/config.hpp
@@ -13,6 +13,18 @@ namespace Config {
 // Lots of these commands are shared between cfg:u, cfg:i, and cfg:s, hence we
 // make no effort to separating them into different namespaces
 
+enum class SystemRegion : uint8_t {
+	JPN = 0,
+	USA = 1,
+	EUR = 2,
+	AUS = 3,
+	CHN = 4,
+	KOR = 5,
+	TWN = 6,
+	
+	Invalid = 0xff,
+};
+
 using GetConfigInfoBlk2 = Platform::IPC::IPCCommand<0x1>::add_uint32::add_uint32::add_buffer_mapping_write
                                        ::response;
 

--- a/source/platform/pxi.hpp
+++ b/source/platform/pxi.hpp
@@ -211,6 +211,9 @@ using RegisterProgram = IPC::IPCCommand<0x2>::add_serialized<ProgramInfo>::add_s
 
 using UnregisterProgram = IPC::IPCCommand<0x3>::add_serialized<ProgramHandle>
                              ::response;
+                             
+using LegacyRegisterProgram = IPC::IPCCommand<0x2>::add_serialized<ProgramInfo>
+                            ::response::add_serialized<ProgramHandle>;
 
 } // namespace PM
 

--- a/source/processes/fs.cpp
+++ b/source/processes/fs.cpp
@@ -103,17 +103,7 @@ public:
         if (program_info.media_type == 0) {
             // TODO: The content ID is hardcoded currently.
             uint32_t content_id = 0;
-            filename = [&]() -> std::string {
-                std::stringstream filename;
-                filename << GetRootDataDirectory(context.settings).string() << "/";
-                filename << std::hex << std::setw(8) << std::setfill('0') << (program_info.program_id >> 32);
-                filename << "/";
-                filename << std::hex << std::setw(8) << std::setfill('0') << (program_info.program_id & 0xFFFFFFFF);
-                filename << "/content/";
-                filename << std::hex << std::setw(8) << std::setfill('0') << content_id;
-                filename << ".cxi";
-                return filename.str();
-            }();
+            filename = (GetRootDataDirectory(context.settings) / fmt::format("title/{:08x}/{:08x}/content/{:08x}.cxi", program_info.program_id >> 32, program_info.program_id & 0xFFFFFFFF, content_id)).string();
             ncch.exceptions(std::ifstream::badbit | std::ifstream::failbit | std::ifstream::eofbit);
             ncch.open(filename);
             auto ncch_start = ncch.tellg();

--- a/source/processes/pxi.cpp
+++ b/source/processes/pxi.cpp
@@ -119,9 +119,8 @@ FakePXI::FakePXI(FakeThread& thread)
     Context context;
 
     // Search for installed NAND titles
-    // TODO: Move titles to ./data/title
     {
-        std::filesystem::path base_path = GetRootDataDirectory(os.settings);
+        std::filesystem::path base_path = GetRootDataDirectory(os.settings) / "title";
 
         auto parse_title_id_part = [](const std::string& filename) -> std::optional<uint32_t> {
             // Expect an 8-digit zero-padded hexadecimal number
@@ -275,17 +274,7 @@ FileFormat::ExHeader GetExtendedHeader(Thread& thread, const Platform::FS::Progr
         // TODO: The following should perhaps be done in the PXIFS subsystem instead
         // TODO: The content ID is hardcoded currently.
         uint32_t content_id = 0;
-        const std::string filename = Meta::invoke([&] {
-            std::stringstream filename;
-            filename << GetRootDataDirectory(thread.GetOS().settings).string();
-            filename << std::hex << std::setw(8) << std::setfill('0') << (title_info.program_id >> 32);
-            filename << "/";
-            filename << std::hex << std::setw(8) << std::setfill('0') << (title_info.program_id & 0xFFFFFFFF);
-            filename << "/content/";
-            filename << std::hex << std::setw(8) << std::setfill('0') << content_id;
-            filename << ".cxi";
-            return filename.str();
-        });
+        const std::string filename = (GetRootDataDirectory(thread.GetOS().settings) / fmt::format("title/{:08x}/{:08x}/content/{:08x}.cxi", title_info.program_id >> 32, title_info.program_id & 0xFFFFFFFF, content_id)).string();
 
         thread.GetLogger()->info("{}Opening \"{}\" to get the extended header", ThreadPrinter{thread}, filename);
         std::ifstream input_file;
@@ -404,6 +393,7 @@ static std::tuple<Result> PMGetExtendedHeader(FakeThread& thread, Context& conte
     return std::make_tuple(RESULT_OK);
 }
 
+
 static std::tuple<Result, PMProgramHandle> PMRegisterProgram(FakeThread& thread, Context& context, PM::ProgramInfo title_info, PM::ProgramInfo update_info) {
     thread.GetLogger()->info("{}received RegisterProgram with title_info={}, update_info={}; attempting to assign internal program handle {:#x}",
                              ThreadPrinter{thread}, title_info, update_info, context.next_program_handle.value);
@@ -421,6 +411,10 @@ static std::tuple<Result, PMProgramHandle> PMRegisterProgram(FakeThread& thread,
     context.next_program_handle.value++;
 
     return std::make_tuple(RESULT_OK, map_entry.first->first);
+}
+
+static std::tuple<Result, PMProgramHandle> PMLegacyRegisterProgram(FakeThread& thread, Context& context, PM::ProgramInfo title_info) {
+    return PMRegisterProgram(thread, context, title_info, PM::ProgramInfo{});
 }
 
 static std::tuple<Result> PMUnregisterProgram(FakeThread& thread, Context& context, PMProgramHandle program_handle) {
@@ -443,7 +437,11 @@ static void PXIPMCommandHandler(FakeThread& thread, Context& context, const IPC:
         return IPC::HandleIPCCommand<PM::GetExtendedHeader>(PMGetExtendedHeader, thread, thread, context);
 
     case PM::RegisterProgram::id:
-        return IPC::HandleIPCCommand<PM::RegisterProgram>(PMRegisterProgram, thread, thread, context);
+        if (header.raw == PM::LegacyRegisterProgram::request_header) {
+            return IPC::HandleIPCCommand<PM::LegacyRegisterProgram>(PMLegacyRegisterProgram, thread, thread, context);
+        }
+        else
+            return IPC::HandleIPCCommand<PM::RegisterProgram>(PMRegisterProgram, thread, thread, context);
 
     case PM::UnregisterProgram::id:
         return IPC::HandleIPCCommand<PM::UnregisterProgram>(PMUnregisterProgram, thread, thread, context);

--- a/source/processes/pxi_fs.cpp
+++ b/source/processes/pxi_fs.cpp
@@ -18,6 +18,7 @@
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/equal.hpp>
 #include <range/v3/algorithm/fill.hpp>
+#include <range/v3/algorithm/find.hpp>
 #include <range/v3/view/counted.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/zip.hpp>
@@ -537,7 +538,7 @@ std::unique_ptr<File> OpenNCCHSubFile(Thread& thread, Platform::FS::ProgramInfo 
         }
 
         auto ncch_filename =    GetRootDataDirectory(thread.GetOS().settings) /
-                                fmt::format("{:08x}/{:08x}/content/{:08x}.cxi",
+                                fmt::format("title/{:08x}/{:08x}/content/{:08x}.cxi",
                                             program_info.program_id >> 32, program_info.program_id & 0xFFFFFFFF, content_id);
         ncch = std::make_unique<HostFile>(ncch_filename.string(), HostFile::Default);
     } else if (gamecard && program_info.media_type == 2) {
@@ -609,16 +610,24 @@ protected:
             auto sub_file = OpenNCCHSubFile(thread, program_info, content_id, sub_file_type, std::basic_string_view<uint8_t> { path.data() + 0xc, 8 }, gamecard);
             return std::make_pair(RESULT_OK, std::move(sub_file));
         } catch (const std::runtime_error& err) {
+            constexpr std::array<uint64_t, 19> bootstrap_bypass_titles = {
+                /* Camera app, probed during initial setup */
+                0x00040010'00020400, 0x00040010'00021400, 0x00040010'00022400,
+                0x00040010'00026400, 0x00040010'00027400, 0x00040010'00028400,
+                /* Nintendo Zone app, probed by HOME Menu on system version 3.0.0 */
+                0x00040010'00020B00, 0x00040010'00021B00, 0x00040010'00022B00, 
+                /* Internet Browser, probed by HOME Menu on system version 9.2.0 */
+                0x00040030'00008802, 0x00040030'00009402, 0x00040030'00009d00,
+                0x00040030'0000A602, 0x00040030'0000AE02, 0x00040030'0000B602,
+                /* In-app Miiverse posting applet, probed by HOME Menu on system versions >= 10.5.0 */
+                0x00040030'00008302, 0x00040030'00008B02, 0x00040030'0000BA02,
+                0x00040030'00000000,
+            };
             if (std::string_view { err.what() }.starts_with("Tried to access non-existing title")) {
                 // Report "not found" for some specific titles that may be
                 // probed by system titles but which won't be present after
                 // NAND bootstrap from gamecard update partitions.
-                // 0x4001000022400: Camera app, probed during initial system setup
-                // 0x4003000009d02: Internet Browser, probed by HOME Menu on system version 9.2.0
-                // 0x400300000ba02: In-app Miiverse posting applet, probed by HOME Menu on system versions >= 10.5.0
-                if (program_info.program_id == 0x4001000022400 ||
-                    program_info.program_id == 0x4003000009d02 ||
-                    program_info.program_id == 0x400300000ba02) {
+                if (ranges::find(bootstrap_bypass_titles, program_info.program_id)) {
                     return std::make_pair(0xc8804478, std::unique_ptr<File> { });
                 }
             }


### PR DESCRIPTION
This adds support for bootstrapping NANDs from any system region, by setting the region value using the CVer title ID found in the system update CFA of the given cart image.

More work is needed for this to work properly, namely because not all cart images contain the shared system fonts. Open-source replacements would be required for those cases.